### PR TITLE
Adding default for advanced_options variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -246,7 +246,9 @@ variable "dedicated_master_type" {
 
 variable "advanced_options" {
   type        = map(string)
-  default     = {}
+  default     = {
+    override_main_response_version = true
+  }
   description = "Key-value string pairs to specify advanced configuration options"
 }
 


### PR DESCRIPTION
## what
* Added a default for advanced_options with override_main_response_version on true incorporated with OpenSearch

## why
* Since Opensearch added this option as default we need to pass it to the module

## references
* REF: https://discuss.hashicorp.com/t/terraform-aws-elastic-search-version-upgrade-to-opensearch-1-0/32401/5

